### PR TITLE
fixed 2 bugs

### DIFF
--- a/app/properties/[id]/page.jsx
+++ b/app/properties/[id]/page.jsx
@@ -18,9 +18,11 @@ const PropertyPage = () => {
     const [loading, setLoading] = useState(true);
 
     const fetchPropertyData = async () => {
+        console.log('ID', id);
         if (!id) return;
         try {
             const property = await fetchProperty(id);
+            console.log(property);
             setProperty(property);
         } catch (error) {
             crossOriginIsolated.error(
@@ -38,7 +40,7 @@ const PropertyPage = () => {
         if (property === null) {
             fetchPropertyData();
         }
-    }, [id, property]);
+    }, [id]);
 
     if (!property && !loading) {
         return (

--- a/components/PropertyCard.jsx
+++ b/components/PropertyCard.jsx
@@ -24,7 +24,7 @@ const PropertyCard = ({ property }) => {
         // <!-- Listing 1 -->
         <div className='rounded-xl shadow-md relative'>
             <Image
-                src={`/images/properties/${property.images[0]}`}
+                src={property.images[0]}
                 alt=''
                 height={0}
                 width={0}

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -32,13 +32,13 @@ async function fetchProperty(id) {
             return null;
         }
 
-        const res = await fetch(`${apiDomain}/properties`, {cache: 'no-store'});
+        const response = await fetch(`${apiDomain}/properties/${id}`, {cache: 'no-store'});
 
-        if (!res.ok) {
+        if (!response.ok) {
             throw new Error('Failed to fetch data');
         }
 
-        return res.json();
+        return response.json();
     } catch (error) {
         console.log(error);
         return null;


### PR DESCRIPTION
1. Property pages infinitely reloading: There was an infinite loop with a useEffect in the property card. Reviewed useEffects and removed the `property` that was being updated in the function that the useEffects was calling.

2. API call was returning the data of all the properties because `apidomain/properties` was missing the specifier of id (should've been `apidomain/properties/${id}` which gave the intended data for only the property associated with said id. 